### PR TITLE
OS X + Python 3

### DIFF
--- a/pycllp/common/myalloc.h
+++ b/pycllp/common/myalloc.h
@@ -10,7 +10,9 @@
 /*
 #include <dmalloc.h>
 */
+#ifndef __APPLE__
 #include <malloc.h>
+#endif
 
 #undef MALLOC
 #define	MALLOC(name,len,type) {	\

--- a/pycllp/hsd.py
+++ b/pycllp/hsd.py
@@ -11,9 +11,9 @@ Port to Python
 """
 from __future__ import print_function
 import numpy as np
-from linalg import smx, atnum
-from ldlt import LDLTFAC
-from lp import LP
+from .linalg import smx, atnum
+from .ldlt import LDLTFAC
+from .lp import LP
 
 EPS = 1.0e-12
 MAX_ITER = 200

--- a/pycllp/ldlt.py
+++ b/pycllp/ldlt.py
@@ -9,7 +9,7 @@ Port to Python
     2015
 """
 import numpy as np
-from linalg import smx
+from .linalg import smx
 import sys
 from . import BDD_BELOW, INFINITE, FREEVAR, UNCONST
 
@@ -642,7 +642,7 @@ class LDLTFAC(object):
 
         for j in range(n):
             ne = kA[j+1] - kA[j] + kQ[j+1] - kQ[j]
-            print j, ne, kA
+            print(j, ne, kA)
             nbrs[j] = np.empty(ne, dtype=np.int)
             ne = 0
             for k in range(kA[j], kA[j+1]):
@@ -987,7 +987,7 @@ class LDLTFAC(object):
                 degree[nbr]-=1
                 nbr_deg = degree[nbr]
                 kk = 0
-                print nbrs
+                print(nbrs)
                 while nbr_nbrs[kk] != node:
                     kk+=1
                 for kk in range(kk,nbr_deg):

--- a/pycllp/solvers/__init__.py
+++ b/pycllp/solvers/__init__.py
@@ -5,7 +5,8 @@ solver_registry = {}
 class MetaSolver(type):
     def __new__(cls, clsname, bases, attrs):
         newclass = super(MetaSolver, cls).__new__(cls, clsname, bases, attrs)
-        solver_registry[newclass.name] = newclass
+        if newclass.name is not None:
+            solver_registry[newclass.name] = newclass
         return newclass
 
 class BaseSolver(with_metaclass(MetaSolver)):

--- a/pycllp/solvers/__init__.py
+++ b/pycllp/solvers/__init__.py
@@ -1,13 +1,16 @@
+from six import with_metaclass
+
 solver_registry = {}
 
-class BaseSolver(object):
-    class __metaclass__(type):
-        def __init__(cls, name, bases, dct):
-            type.__init__(cls, name, bases, dct)
-            if cls.name is not None:
-                solver_registry[cls.name] = cls
-    name = None
+class MetaSolver(type):
+    def __new__(cls, clsname, bases, attrs):
+        newclass = super(MetaSolver, cls).__new__(cls, clsname, bases, attrs)
+        solver_registry[newclass.name] = newclass
+        return newclass
 
+class BaseSolver(with_metaclass(MetaSolver)):
+    name = None
+    
     def init(self, A, b, c, f=0.0):
         raise NotImplementedError()
 
@@ -16,6 +19,6 @@ class BaseSolver(object):
 
 
 # register solvers
-from cython import CyHSDSolver
-from hsd import HSDSolver
-from cl import ClHSDSolver
+from .cython import CyHSDSolver
+from .hsd import HSDSolver
+from .cl import ClHSDSolver

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ cyipo = Extension('pycllp._ipo',
     )
 
 setup(name='pycllp',
-      packages=['pycllp'],
+      packages=['pycllp', 'pycllp.solvers'],
       install_requires=['cython>0.17'],
       ext_modules=[cyipo],
       cmdclass = {'build_ext': build_ext})


### PR DESCRIPTION
A few tweaks to get things working on OS X and in theory Python 3. The tests aren't passing, but at least they're running. Have a look at how the metaclass for the solvers is done; this is how I've done it in pywr, and apparently is the way to do it for 2+3 compatibility.

Check this doesn't break everything at your end before pulling!
